### PR TITLE
Capture count and exists queries

### DIFF
--- a/lib/instrumental/reporters/database.rb
+++ b/lib/instrumental/reporters/database.rb
@@ -62,6 +62,8 @@ module Instrumental
         "active_record.#{instrumentable_for_table_name($1)}.update"
       elsif sql =~ /^DELETE FROM `([a-z_]+)` /
         "active_record.#{instrumentable_for_table_name($1)}.destroy"
+      elsif sql =~ /^SELECT .+ FROM `([a-z_]+)` /
+        "active_record.#{instrumentable_for_table_name($1)}.find"
       end
     end
 


### PR DESCRIPTION
This did not capture 'count' or 'exists' type AR queries, because they don't come in with proper name info from rails.
