### PR TITLE
Add Apdex

### DIFF
--- a/app/middleware/application_timing.rb
+++ b/app/middleware/application_timing.rb
@@ -16,7 +16,7 @@ module Metrician
       start_time = Time.now.to_f
       @app.call(env)
     ensure
-      env["REQUEST_TOTAL_TIME"] = (Time.now.to_f - start_time)
+      env["REQUEST_TOTAL_TIME"] ||= (Time.now.to_f - start_time)
     end
 
   end

--- a/app/middleware/request_timing.rb
+++ b/app/middleware/request_timing.rb
@@ -79,6 +79,8 @@ module Metrician
         Metrician.gauge("web.apdex.satisfied", request_time)
       when request_time <= tolerated_threshold
         Metrician.gauge("web.apdex.tolerated", request_time)
+      else
+        Metrician.gauge("web.apdex.frustrated", request_time)
       end
     end
 

--- a/app/middleware/request_timing.rb
+++ b/app/middleware/request_timing.rb
@@ -71,7 +71,7 @@ module Metrician
     def apdex(request_time)
       return unless configuration[:apdex][:enabled]
 
-      satisfied_threshold = configuration[:apdex][:satisfied_threshold].to_f / 1000
+      satisfied_threshold = configuration[:apdex][:satisfied_threshold]
       tolerated_threshold = satisfied_threshold * 4
 
       case

--- a/config/metrician.yaml
+++ b/config/metrician.yaml
@@ -37,6 +37,16 @@
   :route_tracking:
     :enabled: false
 
+  # "apdex" controls the recording of metrics to measure apdex
+  # More here: https://en.wikipedia.org/wiki/Apdex
+  # Note this requires "request" tracking to be enabled
+  :apdex:
+    :enabled: true
+
+    # set the threshold, in ms, above which a request is no longer
+    # considered "sasifactory". The "tolerates" threshold will be
+    # 4x this number.
+    :satisfied_threshold: 2500
 
 # "database" settings control ActiveRecord metric reporting features
 :database:

--- a/config/metrician.yaml
+++ b/config/metrician.yaml
@@ -43,10 +43,10 @@
   :apdex:
     :enabled: true
 
-    # set the threshold, in ms, above which a request is no longer
+    # set the threshold (seconds), above which a request is no longer
     # considered "sasifactory". The "tolerates" threshold will be
     # 4x this number.
-    :satisfied_threshold: 2500
+    :satisfied_threshold: 2.5
 
 # "database" settings control ActiveRecord metric reporting features
 :database:

--- a/spec/metrician_spec.rb
+++ b/spec/metrician_spec.rb
@@ -201,6 +201,8 @@ RSpec.describe Metrician do
           Rack::Builder.app do
             use Metrician::RequestTiming
             use Metrician::ApplicationTiming
+            # This SHOULD be fast enough to fit under our
+            # default threshold of 2.5s :)
             run lambda { |env| [200, {'Content-Type' => 'text/plain'}, ['OK']] }
           end
         end

--- a/spec/metrician_spec.rb
+++ b/spec/metrician_spec.rb
@@ -213,6 +213,7 @@ RSpec.describe Metrician do
 
           agent.should_receive(:gauge).with("web.apdex.satisfied", anything)
           agent.should_not_receive(:gauge).with("web.apdex.tolerated", anything)
+          agent.should_not_receive(:gauge).with("web.apdex.frustrated", anything)
           get "/"
         end
 
@@ -238,6 +239,7 @@ RSpec.describe Metrician do
 
           agent.should_not_receive(:gauge).with("web.apdex.satisfied", anything)
           agent.should_receive(:gauge).with("web.apdex.tolerated", anything)
+          agent.should_not_receive(:gauge).with("web.apdex.frustrated", anything)
           get "/"
         end
       end
@@ -256,12 +258,13 @@ RSpec.describe Metrician do
           end
         end
 
-        specify "apdex is not recorded for transactions" do
+        specify "frustrated is recorded" do
           agent = Metrician.agent
           agent.stub(:gauge)
 
           agent.should_not_receive(:gauge).with("web.apdex.satisfied", anything)
           agent.should_not_receive(:gauge).with("web.apdex.tolerated", anything)
+          agent.should_receive(:gauge).with("web.apdex.frustrated", anything)
           get "/"
         end
       end


### PR DESCRIPTION
[Apdex wikipedia](https://en.wikipedia.org/wiki/Apdex).

This adds three new metrics:

* *GAUGE* `web.apdex.satisfied`
* *GAUGE* `web.apdex.tolerated`
* *GAUGE* `web.apdex.frustrated`

Also adds configuration for those.

So to compute apdex in the UI, we are going to have the following IQL expression:

```
(gauge_count(web.apdex.satisfied) + (gauge_count(web.apdex.tolerating) / 2)) / gauge_count(web.request)
```

-----

These are `gauge` requests so we can do some introspection of the skew of values in the buckets. `web.apdex.frustrated` is not strictly necessary to record to get apdex, but it is also nice to have.

-----

More reading: [full spec](http://apdex.org/documents/ApdexTechnicalSpecificationV11_000.pdf)

-----

Once the rename branch is merged, I'll make this point at master.