### PR TITLE
Rename "Queue" to "Jobs"

### DIFF
--- a/config/metrician.yaml
+++ b/config/metrician.yaml
@@ -68,15 +68,15 @@
     :enabled: true
 
 
-# "queue" settings control reporting metrics when ruby job systems
-# work through their job queues
-:queue:
+# "jobs" settings control reporting metrics when ruby job systems
+# work through their queues
+:jobs:
 
   # hook into job system middleware when presence detected
   :enabled: true
 
   # record the basic timing of every job
-  :process:
+  :run:
     :enabled: true
 
   # record when an error occurs in the a job

--- a/lib/delayed_job/delayed_job_callbacks.rb
+++ b/lib/delayed_job/delayed_job_callbacks.rb
@@ -9,13 +9,13 @@ module Metrician
         ensure
           duration = Time.now - start
           Metrician.gauge("jobs.run", duration) if Metrician.configuration[:jobs][:run][:enabled]
-          Metrician.gauge("jobs.run.#{job_metric_instrumentation_name(worker)}", duration) if Metrician.configuration[:jobs][:job_specific][:enabled]
+          Metrician.gauge("jobs.task.#{job_metric_instrumentation_name(job)}", duration) if Metrician.configuration[:jobs][:job_specific][:enabled]
         end
       end
 
       lifecycle.after(:error) do |job|
         Metrician.increment("jobs.error") if Metrician.configuration[:jobs][:error][:enabled]
-        Metrician.increment("jobs.error.#{job_metric_instrumentation_name(worker)}") if Metrician.configuration[:jobs][:job_specific][:enabled]
+        Metrician.increment("jobs.error.task.#{job_metric_instrumentation_name(job)}") if Metrician.configuration[:jobs][:job_specific][:enabled]
       end
     end
 

--- a/lib/delayed_job/delayed_job_callbacks.rb
+++ b/lib/delayed_job/delayed_job_callbacks.rb
@@ -8,21 +8,20 @@ module Metrician
           block.call(job)
         ensure
           duration = Time.now - start
-          Metrician.gauge("queue.process", duration) if Metrician.configuration[:queue][:process][:enabled]
-          Metrician.gauge("#{job_metric_instrumentation_name(worker)}.process", duration) if Metrician.configuration[:queue][:job_specific][:enabled]
+          Metrician.gauge("jobs.run", duration) if Metrician.configuration[:jobs][:run][:enabled]
+          Metrician.gauge("jobs.run.#{job_metric_instrumentation_name(worker)}", duration) if Metrician.configuration[:jobs][:job_specific][:enabled]
         end
       end
 
       lifecycle.after(:error) do |job|
-        Metrician.increment("queue.error") if Metrician.configuration[:queue][:error][:enabled]
-        Metrician.increment("#{job_metric_instrumentation_name(worker)}.error") if Metrician.configuration[:queue][:job_specific][:enabled]
+        Metrician.increment("jobs.error") if Metrician.configuration[:jobs][:error][:enabled]
+        Metrician.increment("jobs.error.#{job_metric_instrumentation_name(worker)}") if Metrician.configuration[:jobs][:job_specific][:enabled]
       end
     end
 
     def self.job_metric_instrumentation_name(job)
       # remove all #, ?, !, etc. as well as runs of . and ending .'s
-      name = job.name.gsub(/[^\w]+/, ".").gsub(/\.+$/, "")
-      "jobs.#{name}"
+      job.name.gsub(/[^\w]+/, ".").gsub(/\.+$/, "")
     end
 
   end

--- a/lib/delayed_job/delayed_job_callbacks.rb
+++ b/lib/delayed_job/delayed_job_callbacks.rb
@@ -9,13 +9,13 @@ module Metrician
         ensure
           duration = Time.now - start
           Metrician.gauge("jobs.run", duration) if Metrician.configuration[:jobs][:run][:enabled]
-          Metrician.gauge("jobs.task.#{job_metric_instrumentation_name(job)}", duration) if Metrician.configuration[:jobs][:job_specific][:enabled]
+          Metrician.gauge("jobs.run.#{job_metric_instrumentation_name(job)}", duration) if Metrician.configuration[:jobs][:job_specific][:enabled]
         end
       end
 
       lifecycle.after(:error) do |job|
         Metrician.increment("jobs.error") if Metrician.configuration[:jobs][:error][:enabled]
-        Metrician.increment("jobs.error.task.#{job_metric_instrumentation_name(job)}") if Metrician.configuration[:jobs][:job_specific][:enabled]
+        Metrician.increment("jobs.error.#{job_metric_instrumentation_name(job)}") if Metrician.configuration[:jobs][:job_specific][:enabled]
       end
     end
 

--- a/lib/delayed_job/delayed_job_callbacks.rb
+++ b/lib/delayed_job/delayed_job_callbacks.rb
@@ -9,13 +9,13 @@ module Metrician
         ensure
           duration = Time.now - start
           Metrician.gauge("jobs.run", duration) if Metrician.configuration[:jobs][:run][:enabled]
-          Metrician.gauge("jobs.run.#{job_metric_instrumentation_name(job)}", duration) if Metrician.configuration[:jobs][:job_specific][:enabled]
+          Metrician.gauge("jobs.run.job.#{job_metric_instrumentation_name(job)}", duration) if Metrician.configuration[:jobs][:job_specific][:enabled]
         end
       end
 
       lifecycle.after(:error) do |job|
         Metrician.increment("jobs.error") if Metrician.configuration[:jobs][:error][:enabled]
-        Metrician.increment("jobs.error.#{job_metric_instrumentation_name(job)}") if Metrician.configuration[:jobs][:job_specific][:enabled]
+        Metrician.increment("jobs.error.job.#{job_metric_instrumentation_name(job)}") if Metrician.configuration[:jobs][:job_specific][:enabled]
       end
     end
 

--- a/lib/metrician/reporters/delayed_job.rb
+++ b/lib/metrician/reporters/delayed_job.rb
@@ -3,7 +3,7 @@ module Metrician
 
     def self.enabled?
       !!defined?(::Delayed::Worker) &&
-        Metrician.configuration[:queue][:enabled]
+        Metrician.configuration[:jobs][:enabled]
     end
 
     def instrument

--- a/lib/metrician/reporters/resque.rb
+++ b/lib/metrician/reporters/resque.rb
@@ -3,7 +3,7 @@ module Metrician
 
     def self.enabled?
       !!defined?(::Resque) &&
-        Metrician.configuration[:queue][:enabled]
+        Metrician.configuration[:jobs][:enabled]
     end
 
     def instrument

--- a/lib/metrician/reporters/sidekiq.rb
+++ b/lib/metrician/reporters/sidekiq.rb
@@ -3,7 +3,7 @@ module Metrician
 
     def self.enabled?
       !!defined?(::Sidekiq) &&
-        Metrician.configuration[:queue][:enabled]
+        Metrician.configuration[:jobs][:enabled]
     end
 
     def instrument

--- a/lib/resque/resque_plugin.rb
+++ b/lib/resque/resque_plugin.rb
@@ -10,13 +10,13 @@ module Metrician
     ensure
       duration = Time.now - start
       Metrician.gauge("jobs.run", duration) if Metrician.configuration[:jobs][:run][:enabled]
-      Metrician.gauge("jobs.run.#{Metrician::ResqueHelper.job_metric_instrumentation_name(self)}", duration) if Metrician.configuration[:jobs][:job_specific][:enabled]
+      Metrician.gauge("jobs.run.job.#{Metrician::ResqueHelper.job_metric_instrumentation_name(self)}", duration) if Metrician.configuration[:jobs][:job_specific][:enabled]
       Metrician.agent.cleanup
     end
 
     def on_failure_with_metrician(_e, *_args)
       Metrician.increment("jobs.error") if Metrician.configuration[:jobs][:error][:enabled]
-      Metrician.increment("jobs.error.#{Metrician::ResqueHelper.job_metric_instrumentation_name(self)}") if Metrician.configuration[:jobs][:job_specific][:enabled]
+      Metrician.increment("jobs.error.job.#{Metrician::ResqueHelper.job_metric_instrumentation_name(self)}") if Metrician.configuration[:jobs][:job_specific][:enabled]
       Metrician.agent.cleanup
     end
 

--- a/lib/resque/resque_plugin.rb
+++ b/lib/resque/resque_plugin.rb
@@ -9,14 +9,14 @@ module Metrician
       yield
     ensure
       duration = Time.now - start
-      Metrician.gauge("queue.process", duration) if Metrician.configuration[:queue][:process][:enabled]
-      Metrician.gauge("#{Metrician::ResqueHelper.job_metric_instrumentation_name(self)}.process", duration) if Metrician.configuration[:queue][:job_specific][:enabled]
+      Metrician.gauge("jobs.run", duration) if Metrician.configuration[:jobs][:run][:enabled]
+      Metrician.gauge("jobs.run.#{Metrician::ResqueHelper.job_metric_instrumentation_name(self)}", duration) if Metrician.configuration[:jobs][:job_specific][:enabled]
       Metrician.agent.cleanup
     end
 
     def on_failure_with_metrician(_e, *_args)
-      Metrician.increment("queue.error") if Metrician.configuration[:queue][:error][:enabled]
-      Metrician.increment("#{Metrician::ResqueHelper.job_metric_instrumentation_name(self)}.error") if Metrician.configuration[:queue][:job_specific][:enabled]
+      Metrician.increment("jobs.error") if Metrician.configuration[:jobs][:error][:enabled]
+      Metrician.increment("jobs.error.#{Metrician::ResqueHelper.job_metric_instrumentation_name(self)}") if Metrician.configuration[:jobs][:job_specific][:enabled]
       Metrician.agent.cleanup
     end
 
@@ -28,8 +28,7 @@ module Metrician
 
     def self.job_metric_instrumentation_name(job)
       # remove all #, ?, !, etc. as well as runs of . and ending .'s
-      name = job.to_s.gsub(/[^\w]+/, ".").gsub(/\.+$/, "")
-      "queue.#{name}"
+      job.to_s.gsub(/[^\w]+/, ".").gsub(/\.+$/, "")
     end
 
   end

--- a/lib/sidekiq/sidekiq_middleware.rb
+++ b/lib/sidekiq/sidekiq_middleware.rb
@@ -5,19 +5,18 @@ module Metrician
       start = Time.now
       yield
     rescue
-      Metrician.increment("queue.error") if Metrician.configuration[:queue][:error][:enabled]
-      Metrician.increment("#{job_metric_instrumentation_name(worker)}.error") if Metrician.configuration[:queue][:job_specific][:enabled]
+      Metrician.increment("jobs.error") if Metrician.configuration[:jobs][:error][:enabled]
+      Metrician.increment("jobs.error.#{job_metric_instrumentation_name(worker)}") if Metrician.configuration[:jobs][:job_specific][:enabled]
       raise
     ensure
       duration = Time.now - start
-      Metrician.gauge("queue.process", duration) if Metrician.configuration[:queue][:process][:enabled]
-      Metrician.gauge("#{job_metric_instrumentation_name(worker)}.process", duration) if Metrician.configuration[:queue][:job_specific][:enabled]
+      Metrician.gauge("jobs.run", duration) if Metrician.configuration[:jobs][:run][:enabled]
+      Metrician.gauge("jobs.run.#{job_metric_instrumentation_name(worker)}", duration) if Metrician.configuration[:jobs][:job_specific][:enabled]
     end
 
     def job_metric_instrumentation_name(worker)
       # remove all #, ?, !, etc. as well as runs of . and ending .'s
-      name = worker.class.name.gsub(/[^\w]+/, ".").gsub(/\.+$/, "")
-      "queue.#{name}"
+      worker.class.name.gsub(/[^\w]+/, ".").gsub(/\.+$/, "")
     end
 
   end

--- a/lib/sidekiq/sidekiq_middleware.rb
+++ b/lib/sidekiq/sidekiq_middleware.rb
@@ -6,12 +6,12 @@ module Metrician
       yield
     rescue
       Metrician.increment("jobs.error") if Metrician.configuration[:jobs][:error][:enabled]
-      Metrician.increment("jobs.error.#{job_metric_instrumentation_name(worker)}") if Metrician.configuration[:jobs][:job_specific][:enabled]
+      Metrician.increment("jobs.error.job.#{job_metric_instrumentation_name(worker)}") if Metrician.configuration[:jobs][:job_specific][:enabled]
       raise
     ensure
       duration = Time.now - start
       Metrician.gauge("jobs.run", duration) if Metrician.configuration[:jobs][:run][:enabled]
-      Metrician.gauge("jobs.run.#{job_metric_instrumentation_name(worker)}", duration) if Metrician.configuration[:jobs][:job_specific][:enabled]
+      Metrician.gauge("jobs.run.job.#{job_metric_instrumentation_name(worker)}", duration) if Metrician.configuration[:jobs][:job_specific][:enabled]
     end
 
     def job_metric_instrumentation_name(worker)

--- a/script/test
+++ b/script/test
@@ -4,13 +4,18 @@ cd "$(dirname "$0")/.."
 
 eval "$(rbenv init - --no-rehash)"
 
+rspec_file_line="$1"
+if [[ "$rspec_file_line" != "" ]]; then
+  rspec_file_line="[${rspec_file_line}]"
+fi
+
 success="true"
 
 for ruby_version in `ruby -ryaml -e 'puts YAML.load(File.read(".travis.yml"))["rvm"].join(" ")'`; do
   {
     echo "testing rub version $ruby_version" &&
       rbenv shell $ruby_version &&
-      bundle exec rake matrix:spec
+      bundle exec rake matrix:spec${rspec_file_line}
   } || success="false"
 done
 

--- a/spec/metrician_spec.rb
+++ b/spec/metrician_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Metrician do
         Metrician.configuration[:jobs][:job_specific][:enabled] = true
         @agent.stub(:gauge)
 
-        @agent.should_receive(:gauge).with("jobs.run.TestDelayedJob", anything)
+        @agent.should_receive(:gauge).with("jobs.run.job.TestDelayedJob", anything)
         Delayed::Job.enqueue(TestDelayedJob.new(success: true))
         Delayed::Worker.new(exit_on_complete: true).start
       end

--- a/spec/metrician_spec.rb
+++ b/spec/metrician_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Metrician do
         Metrician.configuration[:jobs][:job_specific][:enabled] = true
         @agent.stub(:gauge)
 
-        @agent.should_receive(:gauge).with("jobs.task.TestDelayedJob", anything)
+        @agent.should_receive(:gauge).with("jobs.run.TestDelayedJob", anything)
         Delayed::Job.enqueue(TestDelayedJob.new(success: true))
         Delayed::Worker.new(exit_on_complete: true).start
       end

--- a/spec/metrician_spec.rb
+++ b/spec/metrician_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Metrician do
     end
   end
 
-  describe "job queue systems" do
+  describe "job systems" do
     describe "delayed_job" do
       before do
         Metrician.activate
@@ -26,16 +26,16 @@ RSpec.describe Metrician do
 
       specify "DelayedJob is instrumented" do
         @agent.stub(:gauge)
-        @agent.should_receive(:gauge).with("queue.process", anything)
 
+        @agent.should_receive(:gauge).with("jobs.run", anything)
         Delayed::Job.enqueue(TestDelayedJob.new(success: true))
         Delayed::Worker.new(exit_on_complete: true).start
       end
 
       specify "job errors are instrumented" do
         @agent.stub(:increment)
-        @agent.should_receive(:increment).with("queue.error", 1)
 
+        @agent.should_receive(:increment).with("jobs.error", 1)
         Delayed::Job.enqueue(TestDelayedJob.new(error: true))
         Delayed::Worker.new(exit_on_complete: true).start
       end
@@ -50,7 +50,7 @@ RSpec.describe Metrician do
 
       specify "Resque is instrumented" do
         @agent.stub(:gauge)
-        @agent.should_receive(:gauge).with("queue.process", anything)
+        @agent.should_receive(:gauge).with("jobs.run", anything)
 
         # typically Metrician would be loaded in an initalizer
         # and this _extend_ could be done inside the job itself, but here
@@ -61,7 +61,7 @@ RSpec.describe Metrician do
 
       specify "job errors are instrumented" do
         @agent.stub(:increment)
-        @agent.should_receive(:increment).with("queue.error", 1)
+        @agent.should_receive(:increment).with("jobs.error", 1)
 
         # typically Metrician would be loaded in an initalizer
         # and this _extend_ could be done inside the job itself, but here
@@ -86,7 +86,7 @@ RSpec.describe Metrician do
 
       specify "Sidekiq is instrumented" do
         @agent.stub(:gauge)
-        @agent.should_receive(:gauge).with("queue.process", anything)
+        @agent.should_receive(:gauge).with("jobs.run", anything)
 
         # avoid load order error of sidekiq here by just including the
         # worker bits at latest possible time
@@ -95,7 +95,7 @@ RSpec.describe Metrician do
 
       specify "job errors are instrumented" do
         @agent.stub(:increment)
-        @agent.should_receive(:increment).with("queue.error", 1)
+        @agent.should_receive(:increment).with("jobs.error", 1)
 
         # avoid load order error of sidekiq here by just including the
         # worker bits at latest possible time

--- a/spec/metrician_spec.rb
+++ b/spec/metrician_spec.rb
@@ -39,6 +39,15 @@ RSpec.describe Metrician do
         Delayed::Job.enqueue(TestDelayedJob.new(error: true))
         Delayed::Worker.new(exit_on_complete: true).start
       end
+
+      specify "per job instrumentation" do
+        Metrician.configuration[:jobs][:job_specific][:enabled] = true
+        @agent.stub(:gauge)
+
+        @agent.should_receive(:gauge).with("jobs.task.TestDelayedJob", anything)
+        Delayed::Job.enqueue(TestDelayedJob.new(success: true))
+        Delayed::Worker.new(exit_on_complete: true).start
+      end
     end
 
     describe "resque" do


### PR DESCRIPTION
As discussed in person, rename queue to jobs to better reflect what we think the general consensus in the world is on what these things are called.

-----

Will point this at master for merge once rename-metrician branch is merged