### PR TITLE
Update Resque setup to be automatic

### DIFF
--- a/lib/metrician/jobs/resque_plugin.rb
+++ b/lib/metrician/jobs/resque_plugin.rb
@@ -3,34 +3,50 @@
 module Metrician
   module Jobs
     module ResquePlugin
-
-      def around_perform_with_metrician(*_args)
-        start = Time.now
-        yield
-      ensure
-        if Jobs.run?
-          duration = Time.now - start
-          Metrician.gauge(Jobs::RUN_METRIC, duration)
-          if Jobs.job_specific?
-            Metrician.gauge("#{Jobs::RUN_METRIC}.job.#{Jobs.instrumentation_name(self.to_s)}", duration)
+      module Extension
+        def around_perform_with_metrician(*_args)
+          start = Time.now
+          yield
+        ensure
+          if Jobs.run?
+            duration = Time.now - start
+            Metrician.gauge(Jobs::RUN_METRIC, duration)
+            if Jobs.job_specific?
+              Metrician.gauge("#{Jobs::RUN_METRIC}.job.#{Jobs.instrumentation_name(self.to_s)}", duration)
+            end
+            Metrician.agent.cleanup
           end
-          Metrician.agent.cleanup
         end
+
+        def on_failure_with_metrician(_e, *_args)
+          if Jobs.error?
+            Metrician.increment(Jobs::ERROR_METRIC)
+            if Jobs.job_specific?
+              Metrician.increment("#{Jobs::ERROR_METRIC}.job.#{Jobs.instrumentation_name(self.to_s)}")
+            end
+            Metrician.agent.cleanup
+          end
+        end
+
+        ::Resque.before_fork = proc { Metrician.agent.cleanup }
       end
 
-      def on_failure_with_metrician(_e, *_args)
-        if Jobs.error?
-          Metrician.increment(Jobs::ERROR_METRIC)
-          if Jobs.job_specific?
-            Metrician.increment("#{Jobs::ERROR_METRIC}.job.#{Jobs.instrumentation_name(self.to_s)}")
+      module Installer
+        def self.included(base)
+          base.send(:alias_method, :payload_class_without_metrician, :payload_class)
+          base.send(:alias_method, :payload_class, :payload_class_with_metrician)
+        end
+
+        def payload_class_with_metrician
+          payload_class_without_metrician.tap do |klass|
+            unless klass.respond_to?(:around_perform_with_metrician)
+              klass.instance_eval do
+                extend(::Metrician::Jobs::ResquePlugin::Extension)
+              end
+            end
           end
-          Metrician.agent.cleanup
         end
       end
-
-      ::Resque.before_fork = proc { Metrician.agent.cleanup }
-
     end
-
   end
 end

--- a/lib/metrician/reporters/resque.rb
+++ b/lib/metrician/reporters/resque.rb
@@ -8,8 +8,8 @@ module Metrician
 
     def instrument
       require "metrician/jobs/resque_plugin"
-      unless ::Resque::Job.respond_to?(:around_perform_with_metrician)
-        ::Resque::Job.send(:extend, Metrician::Jobs::ResquePlugin)
+      unless ::Resque::Job.method_defined?(:payload_class_with_metrician)
+        ::Resque::Job.send(:include, Metrician::Jobs::ResquePlugin::Installer)
       end
     end
 

--- a/spec/metrician_spec.rb
+++ b/spec/metrician_spec.rb
@@ -130,8 +130,7 @@ RSpec.describe Metrician do
         # typically Metrician would be loaded in an initalizer
         # and this _extend_ could be done inside the job itself, but here
         # we are in a weird situation.
-        TestResqueJob.send(:extend, Metrician::Jobs::ResquePlugin)
-        Resque.enqueue(TestResqueJob, { "success" => true })
+        Resque::Job.create(:default, TestResqueJob, { "success" => true })
       end
 
       specify "job errors are instrumented" do
@@ -141,8 +140,7 @@ RSpec.describe Metrician do
         # typically Metrician would be loaded in an initalizer
         # and this _extend_ could be done inside the job itself, but here
         # we are in a weird situation.
-        TestResqueJob.send(:extend, Metrician::Jobs::ResquePlugin)
-        lambda { Resque.enqueue(TestResqueJob, { "error" => true }) }.should raise_error(StandardError)
+        lambda { Resque::Job.create(:default, TestResqueJob, { "error" => true }) }.should raise_error(StandardError)
       end
     end
 

--- a/spec/metrician_spec.rb
+++ b/spec/metrician_spec.rb
@@ -127,9 +127,6 @@ RSpec.describe Metrician do
         @agent.stub(:gauge)
         @agent.should_receive(:gauge).with("jobs.run", anything)
 
-        # typically Metrician would be loaded in an initalizer
-        # and this _extend_ could be done inside the job itself, but here
-        # we are in a weird situation.
         Resque::Job.create(:default, TestResqueJob, { "success" => true })
       end
 
@@ -137,9 +134,6 @@ RSpec.describe Metrician do
         @agent.stub(:increment)
         @agent.should_receive(:increment).with("jobs.error", 1)
 
-        # typically Metrician would be loaded in an initalizer
-        # and this _extend_ could be done inside the job itself, but here
-        # we are in a weird situation.
         lambda { Resque::Job.create(:default, TestResqueJob, { "error" => true }) }.should raise_error(StandardError)
       end
     end


### PR DESCRIPTION
So you don't have to extend every Resque job class yourself.

The test changes a little to work around the fact that resque caches
the list of methods on each job class when `enqueue` is called, which
is before the magic installation can happen in a test scenario. In
non-test scenarios this shouldn't be a problem because the process
running the jobs will call payload_class first.