### PR TITLE
Add a required ruby version

### DIFF
--- a/metrician.gemspec
+++ b/metrician.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.metadata    = {
     "source_code_uri" => "https://github.com/Instrumental/metrician-ruby"
   }
+  s.required_ruby_version = '>= 2.0.0'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/script/setup
+++ b/script/setup
@@ -43,7 +43,7 @@ for ruby_version in `ruby -ryaml -e 'puts YAML.load(File.read(".travis.yml"))["r
 
   gem list -i gemika >/dev/null || gem install gemika
 
-  rake matrix:install
+  rake -t matrix:install
 done
 
 if ! psql postgres -tc "SELECT 1 FROM pg_database WHERE datname = 'metrician_test'" | grep -q 1; then

--- a/script/setup
+++ b/script/setup
@@ -15,7 +15,6 @@ brew list mysql > /dev/null 2>&1 || (
 
 brew list postgresql > /dev/null 2>&1 || brew install postgresql
 
-# TODO: Install all rubies in .travis
 rbenv which ruby >/dev/null 2>&1 || (brew upgrade ruby-build || true; rbenv install)
 
 # Setup rbenv so we can switch rubies below


### PR DESCRIPTION
This gem doesn't work on < ruby 2, so let's note that fact. This should
prevent people from installing it who shouldn't.