### PR TITLE
Make activesupport dependency explicit

### DIFF
--- a/gemfiles/Gemfile.4.2.sidekiq-4.lock
+++ b/gemfiles/Gemfile.4.2.sidekiq-4.lock
@@ -2,6 +2,7 @@ PATH
   remote: ..
   specs:
     metrician (0.0.10)
+      activesupport (> 0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/Gemfile.5.0.pg.lock
+++ b/gemfiles/Gemfile.5.0.pg.lock
@@ -2,6 +2,7 @@ PATH
   remote: ..
   specs:
     metrician (0.0.10)
+      activesupport (> 0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/Gemfile.dalli_not_memcached.lock
+++ b/gemfiles/Gemfile.dalli_not_memcached.lock
@@ -2,6 +2,7 @@ PATH
   remote: ..
   specs:
     metrician (0.0.10)
+      activesupport (> 0)
 
 GEM
   remote: https://rubygems.org/

--- a/metrician.gemspec
+++ b/metrician.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = %w[lib app]
 
+  s.add_runtime_dependency("activesupport", "> 0")
+
   s.add_development_dependency("instrumental_agent", "~> 0")
   s.add_development_dependency("rubocop", "~> 0")
   s.add_development_dependency("bundler", "~> 1.14")


### PR DESCRIPTION
We depend on a few activesupport methods in Metrician which, if you
happen to load Metrician before activesupport, can cause problems.
Making the dependency explicit means we force activesupport to load.