### PR TITLE
Remove dependence on active_support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ gemfile:
   - gemfiles/Gemfile.4.2.sidekiq-4
   - gemfiles/Gemfile.5.0.pg
   - gemfiles/Gemfile.dalli_not_memcached
+  - gemfiles/Gemfile.minimal
 
 matrix:
   exclude:

--- a/gemfiles/Gemfile.minimal
+++ b/gemfiles/Gemfile.minimal
@@ -1,0 +1,14 @@
+source 'https://rubygems.org'
+
+# Differentiated development dependencies
+gem 'rspec', '~> 3.4'
+
+# Development dependencies
+gem 'instrumental_agent'
+gem 'rake'
+gem 'byebug'
+gem 'gemika'
+gem 'simplecov', :require => false, :group => :test
+
+# Gem under test
+gem 'metrician', :path => '..'

--- a/gemfiles/Gemfile.minimal.lock
+++ b/gemfiles/Gemfile.minimal.lock
@@ -1,0 +1,48 @@
+PATH
+  remote: ..
+  specs:
+    metrician (0.0.10)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    byebug (9.0.6)
+    diff-lcs (1.3)
+    docile (1.1.5)
+    gemika (0.3.2)
+    instrumental_agent (1.0.1)
+    json (2.1.0)
+    rake (12.0.0)
+    rspec (3.6.0)
+      rspec-core (~> 3.6.0)
+      rspec-expectations (~> 3.6.0)
+      rspec-mocks (~> 3.6.0)
+    rspec-core (3.6.0)
+      rspec-support (~> 3.6.0)
+    rspec-expectations (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-mocks (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-support (3.6.0)
+    simplecov (0.15.0)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  byebug
+  gemika
+  instrumental_agent
+  metrician!
+  rake
+  rspec (~> 3.4)
+  simplecov
+
+BUNDLED WITH
+   1.14.2

--- a/lib/metrician.rb
+++ b/lib/metrician.rb
@@ -1,4 +1,5 @@
 require "English"
+require "metrician/core_ext"
 require "metrician/configuration"
 require "metrician/reporter"
 require "metrician/jobs"

--- a/lib/metrician/configuration.rb
+++ b/lib/metrician/configuration.rb
@@ -9,7 +9,7 @@ module Metrician
 
       config = {}
       config_locations.reverse.each do |location|
-        deep_merge!(config, YAML.load_file(location)) if File.exist?(location)
+        config.deep_merge!(YAML.load_file(location)) if File.exist?(location)
       end
       config
     end
@@ -41,25 +41,6 @@ module Metrician
     def self.reset_dependents
       Metrician::Jobs.reset
       Metrician::Middleware.reset
-    end
-
-    def self.deep_merge!(this_hash, other_hash, &block)
-      return this_hash unless other_hash
-      other_hash.each_pair do |current_key, other_value|
-        this_value = this_hash[current_key]
-
-        this_hash[current_key] = if this_value.is_a?(Hash) && other_value.is_a?(Hash)
-          this_value.deep_merge(other_value, &block)
-        else
-          if block_given? && this_hash.key?(current_key)
-            block.call(current_key, this_value, other_value)
-          else
-            other_value
-          end
-        end
-      end
-
-      this_hash
     end
   end
 end

--- a/lib/metrician/core_ext.rb
+++ b/lib/metrician/core_ext.rb
@@ -1,0 +1,48 @@
+begin
+  require 'active_support/core_ext/hash/deep_merge'
+rescue LoadError
+  class Hash
+    # active_support
+    def deep_merge(other_hash, &block)
+      dup.deep_merge!(other_hash, &block)
+    end if !{}.respond_to?(:deep_merge)
+
+    def deep_merge!(other_hash, &block)
+      other_hash.each_pair do |current_key, other_value|
+        this_value = self[current_key]
+
+        self[current_key] = if this_value.is_a?(Hash) && other_value.is_a?(Hash)
+          this_value.deep_merge(other_value, &block)
+        else
+          if block_given? && key?(current_key)
+            block.call(current_key, this_value, other_value)
+          else
+            other_value
+          end
+        end
+      end
+
+      self
+    end if !{}.respond_to?(:deep_merge!)
+  end
+end
+
+begin
+  require 'active_support/core_ext/string/inflections'
+rescue LoadError
+  class String
+    # active_support
+    def underscore
+      camel_cased_word = self
+      return camel_cased_word unless camel_cased_word =~ /[A-Z-]|::/
+      word = camel_cased_word.to_s.gsub(/::/, '/')
+      # word.gsub!(/(?:(?<=([A-Za-z\d]))|\b)(#{inflections.acronym_regex})(?=\b|[^a-z])/) { "#{$1 && '_'}#{$2.downcase}" }
+      word.gsub!(/([A-Z\d]+)([A-Z][a-z])/,'\1_\2')
+      word.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
+      word.tr!("-", "_")
+      word.downcase!
+      word    end
+  end if !"".respond_to?(:underscore)
+end
+
+

--- a/script/test
+++ b/script/test
@@ -19,6 +19,14 @@ for ruby_version in `ruby -ryaml -e 'puts YAML.load(File.read(".travis.yml"))["r
   } || success="false"
 done
 
+minimum_coverage="90"
+if ! bundle exec ruby -e "require 'simplecov'; exit SimpleCov::LastRun.read['result']['covered_percent'] >= ${minimum_coverage}"; then
+  success="false"
+  echo
+  echo "Coverage fell below minimum of ${minimum_coverage}:"
+  cat coverage/.last_run.json
+fi
+
 if [ $success == "true" ]; then
   tput bold    # bold text
   tput setaf 2 # green text

--- a/spec/metrician_spec.rb
+++ b/spec/metrician_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 require "instrumental_agent"
+require "tempfile"
 
 module Metrician
   def self.null_agent(agent_class: Instrumental::Agent)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,6 @@
 require 'simplecov'
 SimpleCov.start
 SimpleCov.command_name "#{RUBY_VERSION}_#{File.basename(ENV["BUNDLE_GEMFILE"])}"
-SimpleCov.minimum_coverage 90
-SimpleCov.refuse_coverage_drop
 
 ENV["RAILS_ENV"] = "test"
 

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -1,33 +1,35 @@
-database = Gemika::Database.new
-database.connect
+if Gemika::Env.gem?('activerecord')
+  database = Gemika::Database.new
+  database.connect
 
-if Gemika::Env.gem?('activerecord', '< 5')
-  class ActiveRecord::ConnectionAdapters::Mysql2Adapter
-    NATIVE_DATABASE_TYPES[:primary_key] = "int(11) auto_increment PRIMARY KEY"
-  end
-end
-
-database.rewrite_schema! do
-
-  create_table :users do |t|
-    t.string :name
-    t.string :email
-    t.string :city
+  if Gemika::Env.gem?('activerecord', '< 5')
+    class ActiveRecord::ConnectionAdapters::Mysql2Adapter
+      NATIVE_DATABASE_TYPES[:primary_key] = "int(11) auto_increment PRIMARY KEY"
+    end
   end
 
-  create_table :delayed_jobs, force: true do |table|
-    table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
-    table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
-    table.text :handler,                 null: false # YAML-encoded string of the object that will do work
-    table.text :last_error                           # reason for last failure (See Note below)
-    table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
-    table.datetime :locked_at                        # Set when a client is working on this object
-    table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
-    table.string :locked_by                          # Who is working on this object (if locked)
-    table.string :queue                              # The name of the queue this job is in
-    table.timestamps null: true
+  database.rewrite_schema! do
+
+    create_table :users do |t|
+      t.string :name
+      t.string :email
+      t.string :city
+    end
+
+    create_table :delayed_jobs, force: true do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+
   end
-
-  add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
-
 end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -1,2 +1,4 @@
-class User < ActiveRecord::Base
+if Gemika::Env.gem?('activerecord')
+  class User < ActiveRecord::Base
+  end
 end

--- a/spec/support/test_rails_app.rb
+++ b/spec/support/test_rails_app.rb
@@ -1,21 +1,23 @@
-require "rails/all"
+if Gemika::Env.gem?('activerecord')
+  require "rails/all"
 
-class TestRailsApp < Rails::Application
-  secrets.secret_token    = "secret_token"
-  secrets.secret_key_base = "secret_key_base"
+  class TestRailsApp < Rails::Application
+    secrets.secret_token    = "secret_token"
+    secrets.secret_key_base = "secret_key_base"
 
-  config.logger = Logger.new($stdout)
-  Rails.logger = config.logger
+    config.logger = Logger.new($stdout)
+    Rails.logger = config.logger
 
-  routes.draw do
-    get "/", to: "foobars#index"
+    routes.draw do
+      get "/", to: "foobars#index"
+    end
   end
-end
 
-class FoobarsController < ActionController::Base
-  include Rails.application.routes.url_helpers
+  class FoobarsController < ActionController::Base
+    include Rails.application.routes.url_helpers
 
-  def index
-    render inline: "foobar response"
+    def index
+      render inline: "foobar response"
+    end
   end
 end

--- a/spec/support/test_sidekiq_worker.rb
+++ b/spec/support/test_sidekiq_worker.rb
@@ -1,8 +1,10 @@
-class TestSidekiqWorker
-  include Sidekiq::Worker
+if Gemika::Env.gem?('sidekiq')
+  class TestSidekiqWorker
+    include Sidekiq::Worker
 
-  def perform(options = {})
-    return if options["success"]
-    raise "suck it nerd" if options["error"]
+    def perform(options = {})
+      return if options["success"]
+      raise "suck it nerd" if options["error"]
+    end
   end
 end


### PR DESCRIPTION
It wasn't explicit before, and caused an issue with capistrano. Instead
of making the dependency explicit we decided to remove it since that's
where we'd like to head in the future anyway.

In order to test this change we needed a minimal gemfile to ensure other
gems didn't add these methods. This would cause tests to fails because
gems weren't loaded, so the tests have been updated to skip themselves
if their dependencies aren't loaded. This also prints messages which can
help us make sure that the tests that are being skipped should actually
be skipped.